### PR TITLE
fix: error: use of enum 'ExplorerTransferStates' without previous dec…

### DIFF
--- a/swilib/include/swilib/explorer.h
+++ b/swilib/include/swilib/explorer.h
@@ -15,6 +15,11 @@
 
 __swilib_begin
 
+enum ExplorerTransferStates {
+        EXPLORER_TRANSFER_STATE_STOP            = 1,
+        EXPLORER_TRANSFER_STATE_RUNNING         = 2,
+};
+
 typedef enum ExplorerTransferStates ExplorerTransferStates;
 
 typedef struct NativeExplorerData NativeExplorerData;
@@ -26,11 +31,6 @@ typedef struct REGEXPLEXT TREGEXPLEXT;
 #else
 typedef struct REGEXPLEXT_ARM_NEW TREGEXPLEXT;
 #endif
-
-enum ExplorerTransferStates {
-	EXPLORER_TRANSFER_STATE_STOP		= 1,
-	EXPLORER_TRANSFER_STATE_RUNNING		= 2,
-};
 
 /**
  * Mode of the NativeExplorer.


### PR DESCRIPTION
In file included from /home/user/siemens/sdk/swilib/include/swilib.h:54,
                 from src/main.cpp:3:
/home/user/siemens/sdk/swilib/include/swilib/explorer.h:18:14: error: use of enum 'ExplorerTransferStates' without previous declaration
   18 | typedef enum ExplorerTransferStates ExplorerTransferStates;
      |              ^~~~~~~~~~~~~~~~~~~~~~
/home/user/siemens/sdk/swilib/include/swilib/explorer.h:30:6: error: using typedef-name 'ExplorerTransferStates' after 'enum'
   30 | enum ExplorerTransferStates {
      |      ^~~~~~~~~~~~~~~~~~~~~~
/home/user/siemens/sdk/swilib/include/swilib/explorer.h:18:37: note: 'ExplorerTransferStates' has a previous declaration here
   18 | typedef enum ExplorerTransferStates ExplorerTransferStates;
      |                                     ^~~~~~~~~~~~~~~~~~~~~~
make[1]: *** [../rules.mk:265: bin/src/main.o] Ошибка 1
